### PR TITLE
Avoid naming intent operations and switch table in model

### DIFF
--- a/dist/js/app.js
+++ b/dist/js/app.js
@@ -1687,36 +1687,29 @@ function observe(ItemsView) {
   replicate(ItemsView.itemWidthChanged$, inputItemWidthChanged$);
 }
 
-var addItem$ = Rx.Observable
-  .merge(
-    inputAddOneClicks$.map(function () { return {operation: 'add', amount: 1}; }),
-    inputAddManyClicks$.map(function () { return {operation: 'add', amount: 1000}; })
+var addItem$ = Rx.Observable.merge(
+    inputAddOneClicks$.map(function () { return 1; }),
+    inputAddManyClicks$.map(function () { return 1000; })
   );
 
-var removeItem$ = inputRemoveClicks$
-  .map(function (clickEvent) {
-    return {
-      operation: 'remove',
-      id: Number(clickEvent.currentTarget.attributes['data-item-id'].value)
-    };
-  });
+var removeItem$ = inputRemoveClicks$.map(function (clickEvent) {
+  return Number(clickEvent.currentTarget.attributes['data-item-id'].value);
+});
 
 var colorChanged$ = inputItemColorChanged$
   .map(function (inputEvent) {
     return {
-      operation: 'changeColor',
       id: Number(inputEvent.currentTarget.attributes['data-item-id'].value),
       color: inputEvent.currentTarget.value
-    }
+    };
   });
 
 var widthChanged$ = inputItemWidthChanged$
   .map(function (inputEvent) {
     return {
-      operation: 'changeWidth',
       id: Number(inputEvent.currentTarget.attributes['data-item-id'].value),
       width: Number(inputEvent.currentTarget.value)
-    }
+    };
   });
 
 module.exports = {
@@ -1763,39 +1756,44 @@ function reassignId(item, index) {
   return {id: index, color: item.color, width: item.width};
 }
 
-var items$ = Rx.Observable.just([{id: 0, color: 'red', width: 300}])
-  .merge(intentAddItem$)
-  .merge(intentRemoveItem$)
-  .merge(intentColorChanged$)
-  .merge(intentWidthChanged$)
-  .scan(function (listItems, x) {
-    if (Array.isArray(x)) {
-      return x;
-    }
-    else if (x.operation === 'add') {
-      var newItems = [];
-      for (var i = 0; i < x.amount; i++) {
-        newItems.push(createRandomItem());
-      }
-      return listItems.concat(newItems).map(reassignId);
-    }
-    else if (x.operation === 'remove') {
-      return listItems
-        .filter(function (item) { return item.id !== x.id; })
-        .map(reassignId);
-    }
-    else if (x.operation === 'changeColor') {
-      listItems[x.id].color = x.color;
-      return listItems;
-    }
-    else if (x.operation === 'changeWidth') {
-      listItems[x.id].width = x.width;
-      return listItems;
-    }
-    else {
-      return listItems;
-    }
-  });
+var addItemMod$ = intentAddItem$.map(function(amount) {
+  var newItems = [];
+  for (var i = 0; i < amount; i++) {
+    newItems.push(createRandomItem());
+  }
+  return function(listItems) {
+    return listItems.concat(newItems).map(reassignId);
+  };
+});
+
+var removeItemMod$ = intentRemoveItem$.map(function (id) {
+  return function(listItems) {
+    return listItems.filter(function (item) { return item.id !== id; })
+                    .map(reassignId);
+  };
+});
+
+var colorChangedMod$ = intentColorChanged$.map(function(x) {
+  return function(listItems) {
+    listItems[x.id].color = x.color;
+    return listItems;
+  };
+});
+
+var widthChangedMod$ = intentWidthChanged$.map(function (x) {
+  return function(listItems) {
+    listItems[x.id].width = x.width;
+    return listItems;
+  };
+});
+
+var itemModifications = addItemMod$.merge(removeItemMod$).merge(colorChangedMod$).merge(widthChangedMod$);
+
+var item$ = itemModifications.startWith(
+  [{id: 0, color: 'red', width: 300}]
+).scan(function(listItems, modification) {
+  return modification(listItems);
+});
 
 module.exports = {
   observe: observe,

--- a/src/intents/items.js
+++ b/src/intents/items.js
@@ -20,36 +20,29 @@ function observe(ItemsView) {
   replicate(ItemsView.itemWidthChanged$, inputItemWidthChanged$);
 }
 
-var addItem$ = Rx.Observable
-  .merge(
-    inputAddOneClicks$.map(function () { return {operation: 'add', amount: 1}; }),
-    inputAddManyClicks$.map(function () { return {operation: 'add', amount: 1000}; })
+var addItem$ = Rx.Observable.merge(
+    inputAddOneClicks$.map(function () { return 1; }),
+    inputAddManyClicks$.map(function () { return 1000; })
   );
 
-var removeItem$ = inputRemoveClicks$
-  .map(function (clickEvent) {
-    return {
-      operation: 'remove',
-      id: Number(clickEvent.currentTarget.attributes['data-item-id'].value)
-    };
-  });
+var removeItem$ = inputRemoveClicks$.map(function (clickEvent) {
+  return Number(clickEvent.currentTarget.attributes['data-item-id'].value);
+});
 
 var colorChanged$ = inputItemColorChanged$
   .map(function (inputEvent) {
     return {
-      operation: 'changeColor',
       id: Number(inputEvent.currentTarget.attributes['data-item-id'].value),
       color: inputEvent.currentTarget.value
-    }
+    };
   });
 
 var widthChanged$ = inputItemWidthChanged$
   .map(function (inputEvent) {
     return {
-      operation: 'changeWidth',
       id: Number(inputEvent.currentTarget.attributes['data-item-id'].value),
       width: Number(inputEvent.currentTarget.value)
-    }
+    };
   });
 
 module.exports = {


### PR DESCRIPTION
Currently all objects sent through streams from the intent to the model are being tagged with an `operation` property. The model then simply merges them into one stream and handles them based on the `operation` property in an if else chain. As far as I can see that is done in order to end up with `items$` as one single stream.

I do however think that approach is quite ugly. Having to name the different kinds of objects because they end up being mixed together doesn't seem to take advantage of the fact that they are separated to begin with. It doesn't seem very scalable either. Actually you do mention in your splendid introduction to reactive programming that reactive programming should allow us to reduce the amount of if else control structures.

This commit cleans things up by using a variation of a technique I've seen used in [this blog post](http://nullzzz.blogspot.dk/2013/02/chicken-egg-and-baconjs.html) by the author of bacon.js. All the different streams from the intents are mapped into mutator functions that are merged into a single stream and applied trough `scan`.

Please tell me what you think!

Your blog post about MVI was a _very_ interesting read btw :)
