### PR TITLE
Minor clenaups: add jshintrc, lint files, change package.json run scripts

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,4 @@
+{
+  "node": true,
+  "predef": ["window"]
+}

--- a/package.json
+++ b/package.json
@@ -10,13 +10,17 @@
     "vdom-virtualize": "0.0.4"
   },
   "devDependencies": {
-    "browserify": "~2.36.0"
+    "browserify": "~2.36.0",
+    "jscs": "^1.7.3",
+    "jshint": "^2.5.10",
+    "watchify": "^2.1.1"
   },
   "scripts": {
-    "lint": "./node_modules/.bin/jshint src/ ",
-    "jscs": "./node_modules/.bin/jscs src/",
+    "lint": "jshint src/",
+    "jscs": "jscs src/",
     "check": "npm run lint && npm run jscs",
-    "browserify": "./node_modules/.bin/browserify src/app.js -o dist/js/app.js",
+    "browserify": "browserify src/app.js -o dist/js/app.js",
+    "dev": "watchify src/app.js -o dist/js/app.js",
     "preinstall": "rm -rf build && rm -rf node_modules",
     "postinstall": "ln -s ../src node_modules/mvi-example"
   }

--- a/src/intents/items.js
+++ b/src/intents/items.js
@@ -40,7 +40,7 @@ var colorChanged$ = inputItemColorChanged$
       operation: 'changeColor',
       id: Number(inputEvent.currentTarget.attributes['data-item-id'].value),
       color: inputEvent.currentTarget.value
-    }
+    };
   });
 
 var widthChanged$ = inputItemWidthChanged$
@@ -49,7 +49,7 @@ var widthChanged$ = inputItemWidthChanged$
       operation: 'changeWidth',
       id: Number(inputEvent.currentTarget.attributes['data-item-id'].value),
       width: Number(inputEvent.currentTarget.value)
-    }
+    };
   });
 
 module.exports = {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -17,14 +17,14 @@ var delegator;
 
 function renderVTreeStream(vtree$, containerSelector) {
   // Find and prepare the container
-  var container = document.querySelector(containerSelector);
+  var container = window.document.querySelector(containerSelector);
   if (container === null) {
     console.error('Couldn\'t render into unknown \'' + containerSelector + '\'');
     return false;
   }
   container.innerHTML = '';
   // Make the DOM node bound to the VDOM node
-  var rootNode = document.createElement('div');
+  var rootNode = window.document.createElement('div');
   container.appendChild(rootNode);
   vtree$.startWith(h())
     .bufferWithCount(2, 1)


### PR DESCRIPTION
This PR:
- remove path specification from npm run-scripts: npm does it for you already (thus it will work both on linux/win machines regardless of separator being '/' or '\')
- add browserify/jscs/jshint as they were used in scripts
- add dev run script for watchify to run in development
- add .jshintrc file & lint all the files

Known issues: ATM, `npm run check` will fail with

``` bash
> jscs src/

No configuration found. Add a .jscsrc file to your project root or use the -c option.
```

And `ln -s` won't work on windows, probably. There're other ways to extend `require` path searched, but I cannot through in any at this time of the day, sorry.
